### PR TITLE
fix(RawImageDisplayArea): add user_data echo when frame received

### DIFF
--- a/trame_rca/protocol.py
+++ b/trame_rca/protocol.py
@@ -71,3 +71,13 @@ class StreamManager(LinkProtocol):
             adapter.on_interaction(origin, event)
         else:
             print(f"No area {area_name} available for event")
+
+    @exportRpc("trame.rca.ack_id")
+    def on_ack_id(self, area_name, ack_id):
+        # if ack_id is sent with a frame, it is echoed back to the
+        # adapter when the frame is received.
+        adapter = self._area_adapters.get(area_name, None)
+        if adapter:
+            adapter.on_ack_id(ack_id)
+        else:
+            print(f"No area {area_name} available for event")

--- a/vue-components/src/components/DisplayArea.js
+++ b/vue-components/src/components/DisplayArea.js
@@ -29,7 +29,8 @@ export default {
       <image-display-area v-if="display === 'image'" :name="name" :origin="origin" :poolSize="4" />
       <media-source-display-area v-if="display === 'media-source'" :name="name" :origin="origin" />
       <video-decoder-display-area v-if="display === 'video-decoder'" :name="name" :origin="origin" />
-      <raw-image-display-area v-if="display === 'raw-image'" :name="name" :origin="origin" />
+      <raw-image-display-area v-if="display === 'raw-image'" :name="name" :origin="origin"
+        @user_data="(d) => $emit('user_data', d)"/>
     </div>
   `,
 };


### PR DESCRIPTION
When a frame is sent by the server to the RawImageDisplayArea, allow the inclusion of `user_data` in the meta information, which is sent as message back to the server when the frame is received. Allows the server to track if the client is keeping up with the frames sent.