### PR TITLE
Fix RcaRenderScheduler

### DIFF
--- a/examples/00_cone/app.py
+++ b/examples/00_cone/app.py
@@ -22,6 +22,8 @@ server = get_server()
 server.client_type = "vue2"
 ctrl = server.controller
 
+DEFAULT_RESOLUTION = 6
+
 
 @ctrl.add("on_server_ready")
 def init_rca(**kwargs):
@@ -49,6 +51,15 @@ def init_rca(**kwargs):
     renderer.AddActor(actor)
     renderer.ResetCamera()
 
+    @server.state.change("resolution")
+    def update_cone(resolution=DEFAULT_RESOLUTION, **kwargs):
+        cone_source.SetResolution(resolution)
+        view_handler.schedule_render()
+
+
+def update_reset_resolution():
+    server.state.resolution = DEFAULT_RESOLUTION
+
 
 # -----------------------------------------------------------------------------
 # Trame
@@ -57,6 +68,21 @@ def init_rca(**kwargs):
 
 with SinglePageLayout(server) as layout:
     layout.title.set_text("Hello trame")
+
+    with layout.toolbar:
+        vuetify.VSpacer()
+        vuetify.VSlider(
+            v_model=("resolution", DEFAULT_RESOLUTION),
+            min=3,
+            max=60,
+            step=1,
+            hide_details=True,
+            dense=True,
+            style="max-width: 300px",
+        )
+
+        with vuetify.VBtn(icon=True, click=update_reset_resolution):
+            vuetify.VIcon("mdi-undo-variant")
 
     with layout.content:
         with vuetify.VContainer(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ authors = [
 dependencies = [
     "trame-client>=3.4,<4",
     "wslink>=2.1.3",
+    "numpy",
+    "pillow",
+    "pillow-avif-plugin"
 ]
 requires-python = ">=3.9"
 readme = "README.rst"

--- a/tests/test_rca_utils.py
+++ b/tests/test_rca_utils.py
@@ -203,3 +203,14 @@ def test_rca_view_is_interactive(server):
         # Expect image to have been updated following user action
         new_img_url = element.get_attribute("src")
         assert initial_img_url != new_img_url
+
+
+@pytest.mark.parametrize("encoder", [e.value for e in RcaEncoder])
+def test_scheduler_is_compatible_with_string_encoder_format(encoder, a_threed_view):
+    RcaRenderScheduler(
+        a_threed_view,
+        push_callback=MagicMock(),
+        target_fps=20,
+        interactive_quality=0,
+        rca_encoder=encoder,
+    )

--- a/trame_rca/utils.py
+++ b/trame_rca/utils.py
@@ -21,7 +21,7 @@ from vtkmodules.vtkCommonCore import vtkCommand, vtkVersion
 from vtkmodules.vtkWebCore import vtkRemoteInteractionAdapter
 
 
-class RcaEncoder(str, Enum):
+class RcaEncoder(Enum):
     AVIF = "avif"
     JPEG = "jpeg"
     PNG = "png"
@@ -147,7 +147,7 @@ class RcaRenderScheduler:
                 "RcaRenderScheduler is only compatible with VTK RenderWindows."
             )
 
-        self._rca_encoder = rca_encoder or RcaEncoder.JPEG
+        self._rca_encoder = RcaEncoder(rca_encoder or RcaEncoder.JPEG)
         self._push_callback = push_callback
         self._window = window
         self._target_fps = target_fps or 30.0
@@ -224,7 +224,7 @@ class RcaRenderScheduler:
                     self._encode_pool.submit(
                         encode_np_img_to_format_with_meta,
                         np_img,
-                        self._rca_encoder,
+                        self._rca_encoder.value,
                         cols,
                         rows,
                         quality,

--- a/trame_rca/utils.py
+++ b/trame_rca/utils.py
@@ -322,3 +322,9 @@ class RcaViewAdapter:
         vtkRemoteInteractionAdapter.ProcessEvent(self._iren, json.dumps(event))
         if self._do_render_on_interaction:
             self._scheduler.schedule_render()
+
+    def schedule_render(self):
+        """
+        Schedule a render and push to the RCA view when rendering is ready.
+        """
+        self._scheduler.schedule_render()


### PR DESCRIPTION
* Fix RcaRenderScheduler not sending right image type for Python 3.11+
* Add schedule_render method to RcaViewAdapter to simplify triggering refresh

Related to #19 