### PR TITLE
fix(rca_encoder): Fix turbo JPEG encode color

### DIFF
--- a/examples/vtk_cone_simple.py
+++ b/examples/vtk_cone_simple.py
@@ -72,6 +72,7 @@ class ConeApp:
         mapper.SetInputConnection(cone_source.GetOutputPort())
         actor = vtkActor()
         actor.SetMapper(mapper)
+        actor.GetProperty().SetColor(1, 0.8, 0.8)
 
         renderer.AddActor(actor)
         renderer.ResetCamera()

--- a/trame_rca/encoders/turbo_jpeg.py
+++ b/trame_rca/encoders/turbo_jpeg.py
@@ -1,5 +1,5 @@
 from numpy.typing import NDArray
-from turbojpeg import TurboJPEG
+from turbojpeg import TurboJPEG, TJPF_RGB
 from trame_rca.encoders.img import TO_IMAGE_TYPE
 # import time
 
@@ -43,7 +43,7 @@ def encode_np_img_to_bytes(
     # t0 = time.time()
     image = image.reshape((cols, rows, -1))
     image = image[::-1, :, :]
-    result = jpeg.encode(image, quality=quality)
+    result = jpeg.encode(image, quality=quality, pixel_format=TJPF_RGB)
     # t1 = time.time()
     # print(f"tubo-jpeg encode {t1-t0:.04f}s")
 


### PR DESCRIPTION
By default Turbo JPEG uses BGR as pixel format. Fixed the encode call to use RGB.