### PR TITLE
fix(ci): Fix missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "trame-client>=3.4,<4",
     "wslink>=2.1.3",
     "numpy",
+    "packaging",
     "pillow",
     "pillow-avif-plugin"
 ]


### PR DESCRIPTION
The `packaging` module was added in commit 263aad6c241d436dc2ec10a1ceb14a108d099a3c but it was missing from the requirements of this package.

cc: @finetjul 