### PR TITLE
fix(utils): do not import vtk unnecessarily

### DIFF
--- a/examples/00_vanilla/vanilla_example.py
+++ b/examples/00_vanilla/vanilla_example.py
@@ -4,7 +4,6 @@ from PIL import Image
 from trame.app.testing import enable_testing
 from trame.decorators import TrameApp, change
 from trame_rca.widgets import rca
-from trame_rca.utils import AbstractWindow
 from trame.app import get_server
 from trame.ui.vuetify3 import SinglePageLayout
 from trame.widgets import vuetify3 as v3
@@ -14,7 +13,7 @@ from trame_client.module.vue3 import www
 DEFAULT_ROTATION_STEP = 45
 
 
-class RotatableImageWindow(AbstractWindow):
+class RotatableImageWindow:
     def __init__(self, path):
         self._image = Image.open(path).convert("RGB")
         self._image_angle = 0

--- a/trame_rca/protocol.py
+++ b/trame_rca/protocol.py
@@ -1,5 +1,47 @@
+from typing import Protocol, runtime_checkable
+from numpy.typing import NDArray
 from wslink import register as exportRpc
 from wslink.websocket import LinkProtocol
+
+
+@runtime_checkable
+class AbstractWindow(Protocol):
+    """
+    Protocol defining the interface for interacting with a remote window through RCA.
+
+    Any class matching this interface can be used as a remote window, regardless of inheritance.
+    Implementing classes must define the required methods and properties to enable window interaction.
+    """
+
+    @property
+    def img_cols_rows(self) -> tuple[NDArray, int, int]:
+        """
+        Returns a tuple containing:
+        - the window content as a NumPy array,
+        - the number of columns,
+        - and the number of rows.
+
+        Called by the scheduler to render the current window view.
+        """
+        pass
+
+    def process_resize_event(self, width: int, height: int) -> None:
+        """
+        Handle a resize event for the RCA (RenderWindowInteractor).
+
+        This method is triggered by the adapter whenever the window is resized.
+        """
+        pass
+
+    def process_interaction_event(self, event: dict) -> None:
+        """
+        Handle an interaction event from the RCA (RenderWindowInteractor).
+
+        This method is invoked by the adapter whenever an interaction event occurs.
+        Refer to the event types defined in:
+        https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/Core/RenderWindowInteractor/index.js
+        """
+        pass
 
 
 class AreaAdapter:

--- a/trame_rca/vtk_utils.py
+++ b/trame_rca/vtk_utils.py
@@ -1,0 +1,46 @@
+import json
+from packaging.version import Version
+from vtkmodules.util.numpy_support import vtk_to_numpy
+from vtkmodules.vtkCommonCore import vtkCommand, vtkVersion
+from vtkmodules.vtkRenderingCore import vtkRenderWindow, vtkWindowToImageFilter
+from vtkmodules.vtkWebCore import vtkRemoteInteractionAdapter
+
+
+class VtkWindow:
+    def __init__(self, vtk_render_window: vtkRenderWindow):
+        self._vtk_render_window = vtk_render_window
+        self._window_to_image = vtkWindowToImageFilter()
+        self._window_to_image.SetInput(vtk_render_window)
+        self._window_to_image.SetScale(1)
+        self._window_to_image.ReadFrontBufferOff()
+        self._window_to_image.ShouldRerenderOff()
+        self._window_to_image.FixBoundaryOn()
+        self._iren = self._vtk_render_window.GetInteractor()
+        self._iren.EnableRenderOff()
+        self._vtk_render_window.ShowWindowOff()
+
+    @property
+    def img_cols_rows(self):
+        self._vtk_render_window.Render()
+        self._window_to_image.Modified()
+        self._window_to_image.Update()
+
+        image_data = self._window_to_image.GetOutput()
+        rows, cols, _ = image_data.GetDimensions()
+        scalars = image_data.GetPointData().GetScalars()
+        np_image = vtk_to_numpy(scalars)
+        np_image = np_image.reshape((cols, rows, -1))
+        np_image[:] = np_image[::-1, :, :]
+        return np_image, cols, rows
+
+    def process_resize_event(self, width, height):
+        self._iren.UpdateSize(width, height)
+        if Version(vtkVersion().vtk_version) < Version("9.5"):
+            self._iren.InvokeEvent(vtkCommand.WindowResizeEvent)
+
+    def process_interaction_event(self, event):
+        event_type = event["type"]
+        if event_type in ["StartInteractionEvent", "EndInteractionEvent"]:
+            return
+
+        vtkRemoteInteractionAdapter.ProcessEvent(self._iren, json.dumps(event))

--- a/trame_rca/vtk_utils.py
+++ b/trame_rca/vtk_utils.py
@@ -1,5 +1,6 @@
 import json
 from packaging.version import Version
+import vtkmodules.vtkRenderingOpenGL2  # noqa
 from vtkmodules.util.numpy_support import vtk_to_numpy
 from vtkmodules.vtkCommonCore import vtkCommand, vtkVersion
 from vtkmodules.vtkRenderingCore import vtkRenderWindow, vtkWindowToImageFilter


### PR DESCRIPTION
As vtk is not in the project dependencies, a `ModuleNotFoundError` on `vtkmodules` is generated when the `utils` are imported even if vtk is an optional dependency

The AbstractWindow is now a Protocol and the VtkWindow is in its own vtk_utils which is optionally imported if vtk has been installed.
No breaking change.