### PR TITLE
Fix multiple rca

### DIFF
--- a/examples/01_vtk/vtk_cone_simple.py
+++ b/examples/01_vtk/vtk_cone_simple.py
@@ -18,6 +18,7 @@ from trame.ui.vuetify3 import SinglePageLayout
 from trame.widgets import vuetify3 as v3
 
 # use this import path to allow -e install for dev
+from trame_rca.protocol import StreamManager
 from trame_rca.widgets import rca
 
 v3.enable_lab()
@@ -34,6 +35,15 @@ class ConeApp(TrameApp):
         self.state.encoder = args.encoder
         self.render_window, self.cone_source = self.setup_vtk()
         self.build_ui()
+
+        self.ctrl.on_server_ready.add(self._allow_drop_frames)
+
+    def _allow_drop_frames(self, **_):
+        """Allow to drop frames when network is overloaded"""
+        stream_manager: StreamManager = (
+            self.server.root_server.controller.get_stream_manager()
+        )
+        stream_manager.allow_drop_frames = True
 
     def setup_vtk(self):
         renderer = vtkRenderer()

--- a/src/trame_rca/module/__init__.py
+++ b/src/trame_rca/module/__init__.py
@@ -14,8 +14,13 @@ vue_use = ["trame_rca"]
 def setup(server, **kwargs):
     def configure_protocol(root_protocol):
         protocol_instance = StreamManager()
+
+        def _get_stream_manager():
+            return protocol_instance
+
         server.controller.rc_area_register = protocol_instance.register_area
         server.controller.rc_area_unregister = protocol_instance.unregister_area
+        server.controller.get_stream_manager = _get_stream_manager
         root_protocol.registerLinkProtocol(protocol_instance)
 
     server.add_protocol_to_configure(configure_protocol)

--- a/src/trame_rca/protocol.py
+++ b/src/trame_rca/protocol.py
@@ -44,7 +44,16 @@ class AreaAdapter:
 class StreamManager(LinkProtocol):
     def __init__(self):
         super().__init__()
+        self._allow_drop_frames = False
         self._area_adapters = {}
+
+    @property
+    def allow_drop_frames(self) -> bool:
+        return self._allow_drop_frames
+
+    @allow_drop_frames.setter
+    def allow_drop_frames(self, v: bool):
+        self._allow_drop_frames = v
 
     def register_area(self, area_adapter):
         self._area_adapters[area_adapter.area_name] = area_adapter
@@ -64,7 +73,7 @@ class StreamManager(LinkProtocol):
 
     @exportRpc("trame.rca.push")
     def push_content(self, area_name, metadata, content):
-        if self.coreServer.network_monitor.pending > 5:
+        if self._allow_drop_frames and self.coreServer.network_monitor.pending > 5:
             # Drop frames when network is overloaded
             profiler.LOGGER.action("rca.protocol.drop-frame")
             return

--- a/vue-components/src/style.css
+++ b/vue-components/src/style.css
@@ -29,15 +29,12 @@
   left: 0;
   width: 100%;
   height: 100%;
-  --x-padding: 2px;
-  --y-padding: 2px;
+  --video-padding: 4px;
 }
 
 .video-decoder-display-area canvas {
-  width: calc(100% + var(--x-padding));
-  height: calc(100% + var(--y-padding));
-  top: calc(var(--y-padding) * -0.5);
-  left: calc(var(--x-padding) * -0.5);
+  width: calc(100% + var(--video-padding));
+  height: calc(100% + var(--video-padding));
   position: relative;
 }
 


### PR DESCRIPTION
Changes:

- Add flag that tells whether we should drop frames in case of overload. `widgets.rca.RemoteControlledArea.create_view_handler` set it to `False` in case of `display=="video-decoder"`
- Fix video padding: some green pixels were still showing because the canvas was centered instead of overflowing only on right and bottom. When the video encoder is larger than the render window it adds padding (green pixels) only at the right and at the bottom of the frame.