### PR TITLE
Retry on overload

### DIFF
--- a/src/trame_rca/encoders/video_encoder.py
+++ b/src/trame_rca/encoders/video_encoder.py
@@ -1,4 +1,5 @@
 from time import time_ns
+from typing import Callable
 import logging
 
 from vtkmodules.vtkCommonCore import vtkUnsignedCharArray
@@ -51,11 +52,15 @@ def encode(
 
 
 class RcaVideoEncoder:
-    def __init__(self, render_window: vtkRenderWindow) -> None:
+    def __init__(
+        self,
+        render_window: vtkRenderWindow,
+        push_callback: Callable[[bytes, dict, int], None],
+    ) -> None:
         self._render_window = render_window
         self.encoder = None
         self.frame = None
-        self._push_callback = None
+        self._push_callback = push_callback
         self._window_size = None
 
         if vtkNvEncoderGL.CheckAvailability():
@@ -100,9 +105,6 @@ class RcaVideoEncoder:
         self.release()
         self._initialize(render_window)
 
-    def set_push_callback(self, callback):
-        self._push_callback = callback
-
     @calldata_type(VTK_OBJECT)
     def _on_encoded_chunk(
         self,
@@ -113,7 +115,7 @@ class RcaVideoEncoder:
         now_ms = int(time_ns() / 1000000)
         content, meta, _ = encode(video_packet, now_ms)
         if self._push_callback is not None:
-            self._push_callback(content, meta)
+            self._push_callback(content, meta, now_ms)
 
     def encode(self, render_window: vtkRenderWindow):
         if self.encoder is None or self.frame is None:

--- a/src/trame_rca/schedulers/video_scheduler.py
+++ b/src/trame_rca/schedulers/video_scheduler.py
@@ -34,7 +34,9 @@ class RcaVideoRenderScheduler:
         target_fps: float = 30.0,
     ):
         self._rca: VtkRemoteControlledArea = window_wrapper(window)
-        self._rca_encoder = RcaVideoEncoder(self._rca.render_window)
+        self._rca_encoder = RcaVideoEncoder(
+            self._rca.render_window, push_callback=self._push
+        )
         self._is_closing = False
         self._render_requested = False
 
@@ -48,8 +50,8 @@ class RcaVideoRenderScheduler:
     def rca(self) -> VtkRemoteControlledArea:
         return self._rca
 
-    def set_push_callback(self, callback: Callable[[bytes, dict], None]):
-        self._rca_encoder.set_push_callback(callback)
+    def set_push_callback(self, callback: Callable[[bytes, dict], bool]):
+        self._push_callback = callback
 
     @property
     def target_fps(self):
@@ -84,3 +86,6 @@ class RcaVideoRenderScheduler:
                 self._rca_encoder.encode(render_window)
 
             await sleep(self._target_period_s)
+
+    def _push(self, content: bytes, meta: dict, _m_time: int):
+        self._push_callback(content, meta)

--- a/tests/test_rca_video.py
+++ b/tests/test_rca_video.py
@@ -18,10 +18,9 @@ if os.environ.get("CI") is not None and sys.platform != "linux":
 
 
 def test_a_view_can_be_encoded_to_format(a_render_window, tmpdir):
-    rca_encoder = RcaVideoEncoder(a_render_window)
     a_mock_push = MagicMock()
+    rca_encoder = RcaVideoEncoder(a_render_window, a_mock_push)
 
-    rca_encoder.set_push_callback(a_mock_push)
     rca_encoder.encode(a_render_window)
 
     time.sleep(1)

--- a/vue-components/src/style.css
+++ b/vue-components/src/style.css
@@ -29,15 +29,12 @@
   left: 0;
   width: 100%;
   height: 100%;
-  --x-padding: 2px;
-  --y-padding: 2px;
+  --video-padding: 4px;
 }
 
 .video-decoder-display-area canvas {
-  width: calc(100% + var(--x-padding));
-  height: calc(100% + var(--y-padding));
-  top: calc(var(--y-padding) * -0.5);
-  left: calc(var(--x-padding) * -0.5);
+  width: calc(100% + var(--video-padding));
+  height: calc(100% + var(--video-padding));
   position: relative;
 }
 


### PR DESCRIPTION
Alternative PR to #36 to handle multiple RCA fixing overload problem

Changes:
- on overload the schedulers reschedule the push_content with a delay
- Fix video padding: some green pixels were still showing because the canvas was centered instead of overflowing only on right and bottom. When the video encoder is larger than the render window it adds padding (green pixels) only at the right and at the bottom of the frame.