### PR TITLE
feat: handle two-finger gestures

### DIFF
--- a/vue-components/src/utils/interactorStyle.js
+++ b/vue-components/src/utils/interactorStyle.js
@@ -199,12 +199,13 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
 
   publicAPI.handleStartPinch = (callData) => {
     publicAPI.startDolly();
-    const { scale } = callData;
+    const { scale: factor, touches: positions } = callData;
     // model._interactor.requestAnimation(publicAPI.handleStartPinch);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteGestureEvent({
       type: 'StartPinch',
-      scale,
+      factor,
+      positions,
       ...model.remoteEventAddOn,
     });
   };
@@ -212,10 +213,15 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
   //----------------------------------------------------------------------------
 
   publicAPI.handlePinch = (callData) => {
-    const { scale } = callData;
+    const { scale: factor, touches: positions } = callData;
+    model.lastPinchEvent = {
+      factor,
+      positions,
+    };
     publicAPI.invokeRemoteGestureEvent({
       type: 'Pinch',
-      scale,
+      factor,
+      positions,
       ...model.remoteEventAddOn,
     });
   };
@@ -226,6 +232,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
     publicAPI.endDolly();
     publicAPI.invokeRemoteGestureEvent({
       type: 'EndPinch',
+      ...model.lastPinchEvent,
       ...model.remoteEventAddOn,
     });
     // model._interactor.cancelAnimation(publicAPI.handleStartPinch);
@@ -236,12 +243,13 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
 
   publicAPI.handleStartRotate = (callData) => {
     publicAPI.startRotate();
-    const { rotation } = callData;
+    const { rotation, touches: positions } = callData;
     // model._interactor.requestAnimation(publicAPI.handleStartRotate);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteGestureEvent({
       type: 'StartRotate',
       rotation,
+      positions,
       ...model.remoteEventAddOn,
     });
   };
@@ -249,10 +257,15 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
   //----------------------------------------------------------------------------
 
   publicAPI.handleRotate = (callData) => {
-    const { rotation } = callData;
+    const { rotation, touches: positions } = callData;
+    model.lastRotateEvent = {
+      rotation,
+      positions,
+    };
     publicAPI.invokeRemoteGestureEvent({
       type: 'Rotate',
       rotation,
+      positions,
       ...model.remoteEventAddOn,
     });
   };
@@ -263,6 +276,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
     publicAPI.endRotate();
     publicAPI.invokeRemoteGestureEvent({
       type: 'EndRotate',
+      ...model.lastRotateEvent,
       ...model.remoteEventAddOn,
     });
     // model._interactor.cancelAnimation(publicAPI.handleStartRotate);
@@ -273,12 +287,13 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
 
   publicAPI.handleStartPan = (callData) => {
     publicAPI.startPan();
-    const { translation } = callData;
+    const { translation, touches: positions } = callData;
     // model._interactor.requestAnimation(publicAPI.handleStartPan);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteGestureEvent({
       type: 'StartPan',
       translation,
+      positions,
       ...model.remoteEventAddOn,
     });
   };
@@ -286,10 +301,15 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
   //----------------------------------------------------------------------------
 
   publicAPI.handlePan = (callData) => {
-    const { translation } = callData;
+    const { translation, touches: positions } = callData;
+    model.lastPanEvent = {
+      translation,
+      positions,
+    };
     publicAPI.invokeRemoteGestureEvent({
       type: 'Pan',
       translation,
+      positions,
       ...model.remoteEventAddOn,
     });
   };
@@ -300,6 +320,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
     publicAPI.endPan();
     publicAPI.invokeRemoteGestureEvent({
       type: 'EndPan',
+      ...model.lastPanEvent,
       ...model.remoteEventAddOn,
     });
     // model._interactor.cancelAnimation(publicAPI.handleStartPan);


### PR DESCRIPTION
# Two-finger gestures not handled

When using a two-finger gestures like Pinch, Rotate or Pan on the `vtk_cone_simple.py` example this error was thrown
```
2024-10-19 20:09:28.342 (  63.079s) [          62BEBB]vtkRemoteInteractionAda:279    ERR| Skipping Event 
[json.exception.out_of_range.403] key 'positions' not found
```

And there was no way to catch the event on the vtk side.

# Investigation
There was a mismatch between the vtk.js events API, the vtkRemoteInteractionAdapter events API, and how trame-rca forwards them

I present the problem here with the Pinch events, but the same happens with Pan and Rotate

vtk.js gesture event API (https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/Core/RenderWindowInteractor/index.js, publicAPI.recognizeGesture line 1204)
```js
{ type='startPinch', scale: float, touches={"2": {"x": ..., "y": ..., "z": 0}}, "3": {"x": ..., "y": ..., "z": 0} }
{ type='Pinch'     , scale: float, touches={"2": {"x": ..., "y": ..., "z": 0}}, "3": {"x": ..., "y": ..., "z": 0} }
{ type='endPinch' }
```

trame-rca took it and transmited to vtkRemoteInteractionAdapter (https://github.com/Kitware/trame-rca/blob/master/vue-components/src/utils/interactorStyle.js, publicAPI.handleStartPinch)
```js
{ type='startPinch', scale: float }
{ type='Pinch'     , scale: float }
{ type='endPinch' }
```

vtkRemoteInteractionAdapter.cxx expects (https://github.com/Kitware/VTK/blob/master/Web/Core/vtkRemoteInteractionAdapter.cxx, vtkRemoteInteractionAdapter::ProcessEvent line 201 - ...)

```js
{ type='startPinch', factor: float, positions={"2": {"x": ..., "y": ..., "z": 0}}, "3": {"x": ..., "y": ..., "z": 0} }
{ type='Pinch'     , factor: float, positions={"2": {"x": ..., "y": ..., "z": 0}}, "3": {"x": ..., "y": ..., "z": 0} }
{ type='endPinch'  , factor: float, positions={"2": {"x": ..., "y": ..., "z": 0}}, "3": {"x": ..., "y": ..., "z": 0} }
```

# Resolution

To handle the gestures, this PR translates from the vtk.js API to the vtkRemoteInteractionAdapter's API.
This is done as soon as possible at the component level (in javascript) as the vtk.js is supposed to have the same API as vtk.

As the vtkRemoteInteractionAdapter expects events information for `endPinch`, the last `Pinch` event's information is sent.

# Try it out

There is no example showing the usage of the gestures, should one be added ? I tried MultiTouchCamera interactorStyle instead of TrackBallCamera interactorStyle (in the vtk_cone_simple), it handles the pinch for zooming but weirdly, at least it shows that the gestures events can be handled by vtk.

to try this out use 
```python
renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToMultiTouchCamera()
```
instead of
```python
renderWindowInteractor.GetInteractorStyle().SetCurrentStyleToTrackballCamera()
```
in the `vtk_cone_simple.py`

and run 
```
python ./examples/01_vtk/vtk_cone_simple.py --host 0.0.0.0
```
to allow phone or tablet devices to connect to your IP address