### PR TITLE
Fix vpx encoder shutdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,3 +95,17 @@ You can try our code example:
     pip install "trame-rca[vtkstreaming]"
 
     python ./examples/05_video/vtk_cone_simple_video.py
+
+In order to use source-build of vtkstreaming, please clone [VTKStreaming](https://github.com/Kitware/VTKStreaming.git) one level
+up outside the trame-rca directory, checkout the `wheel` branch, and install it inside the trame-rca virtual environment
+
+.. code-block:: console
+
+    cd ..
+    git clone https://github.com/Kitware/VTKStreaming.git
+    cd VTKstreaming
+    uv pip install --group dev          # build deps into active venv; index from tool.uv.index
+    uv pip install -e . --no-build-isolation
+    cd ../trame-rca
+
+    python ./examples/05_video/vtk_cone_simple_video.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,8 @@ turbo = [
 ]
 vtkstreaming = [
     "vtk",
-    "vtk-streaming>=0.3.2",
+    "vtk-streaming>=0.3.4",
 ]
-
-
-
-
-
-
-
 
 [build-system]
 requires = ["hatchling"]

--- a/src/trame_rca/encoders/video_encoder.py
+++ b/src/trame_rca/encoders/video_encoder.py
@@ -81,7 +81,7 @@ class RcaVideoEncoder:
     def _initialize(self, render_window: vtkRenderWindow):
         self.encoder.SetGraphicsContext(render_window)
         self.encoder.SetInputPixelFormat(VTKPF_IYUV)
-        self.encoder.SetBitRateControlMode(3)  # Constant quantization
+        self.encoder.SetBitRateControlMode(vtkVideoEncoder.BRCType.CQP)
         self.encoder.SetQuantizationParameter(5)  # 0 (high quality) - 63 (low quality)
 
         self.frame = vtkOpenGLVideoFrame()
@@ -115,8 +115,7 @@ class RcaVideoEncoder:
         if self.encoder is None or self.frame is None:
             return
         if self._window_size != render_window.GetSize():
-            # Ideally we would just call _set_size here
-            self._reset(render_window)
+            self._set_size(render_window_size=render_window.size)
         self.frame.Capture(render_window)
         self.encoder.Encode(self.frame)
 


### PR DESCRIPTION
- Bumps vtk-streaming to 0.3.4
- Removes unnecessary call to encoder reset upon size change, the encoder automatically detects size changes and rebuilds what is necessary.