### PR TITLE
feat: add throttling of gesture events

### DIFF
--- a/vue-components/src/utils/EventThrottle.js
+++ b/vue-components/src/utils/EventThrottle.js
@@ -47,7 +47,15 @@ export class EventThrottle {
     this.processing = false;
     this.throttleTimeMs = throttleTimeMs;
     this.processCallback = processCallback;
-    this.eventKeysToIgnore = new Set(['x', 'y']);
+    this.eventKeysToIgnore = new Set([
+      'x',
+      'y',
+      // For gesture events:
+      'positions',
+      'rotation',
+      'translation',
+      'factor',
+    ]);
   }
 
   /**


### PR DESCRIPTION

This feature was requested in https://github.com/Kitware/trame-rca/pull/44

Two consecutive gesture events of the same type are always compressible so all their keys are added to `eventKeysToIgnore`.

The throttling of events in the `EventThrottle.js` file uses compression, for a list of events, for consecutive compressible events within that list, only the last one is kept. Gesture events of the same type with different properties are now compressible.